### PR TITLE
feat: add MediaStreamTrack support to speech recognition

### DIFF
--- a/src/speech.test.ts
+++ b/src/speech.test.ts
@@ -156,6 +156,91 @@ describe('speech function', () => {
 
     // Assert: 期待される結果を確認
     expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
+    expect(mockRecognitionInstance.start).toHaveBeenCalledWith()
+  })
+
+  it('When calling start method with MediaStreamTrack, it passes the track to recognition.start', () => {
+    // Arrange
+    const recognitionObj = speech({})
+    const mockAudioTrack = {
+      kind: 'audio',
+      readyState: 'live',
+    } as MediaStreamTrack
+
+    // Act
+    recognitionObj.start(mockAudioTrack)
+
+    // Assert
+    expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
+    expect(mockRecognitionInstance.start).toHaveBeenCalledWith(mockAudioTrack)
+  })
+
+  it('When calling start method with video track, it throws InvalidStateError', () => {
+    // Arrange
+    const recognitionObj = speech({})
+    const mockVideoTrack = {
+      kind: 'video',
+      readyState: 'live',
+    } as MediaStreamTrack
+
+    // Act & Assert
+    expect(() => recognitionObj.start(mockVideoTrack)).toThrow(DOMException)
+    expect(() => recognitionObj.start(mockVideoTrack)).toThrow(
+      'The provided MediaStreamTrack must be an audio track'
+    )
+    expect(mockRecognitionInstance.start).not.toHaveBeenCalled()
+  })
+
+  it('When calling start method with ended audio track, it throws InvalidStateError', () => {
+    // Arrange
+    const recognitionObj = speech({})
+    const mockEndedTrack = {
+      kind: 'audio',
+      readyState: 'ended',
+    } as MediaStreamTrack
+
+    // Act & Assert
+    expect(() => recognitionObj.start(mockEndedTrack)).toThrow(DOMException)
+    expect(() => recognitionObj.start(mockEndedTrack)).toThrow(
+      'The provided MediaStreamTrack must be in "live" state'
+    )
+    expect(mockRecognitionInstance.start).not.toHaveBeenCalled()
+  })
+
+  it('When audioTrack is provided in options, it uses that track on start', () => {
+    // Arrange
+    const mockAudioTrack = {
+      kind: 'audio',
+      readyState: 'live',
+    } as MediaStreamTrack
+    const recognitionObj = speech({ audioTrack: mockAudioTrack })
+
+    // Act
+    recognitionObj.start()
+
+    // Assert
+    expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
+    expect(mockRecognitionInstance.start).toHaveBeenCalledWith(mockAudioTrack)
+  })
+
+  it('When both options.audioTrack and parameter audioTrack are provided, parameter takes precedence', () => {
+    // Arrange
+    const optionsTrack = {
+      kind: 'audio',
+      readyState: 'live',
+    } as MediaStreamTrack
+    const parameterTrack = {
+      kind: 'audio',
+      readyState: 'live',
+    } as MediaStreamTrack
+    const recognitionObj = speech({ audioTrack: optionsTrack })
+
+    // Act
+    recognitionObj.start(parameterTrack)
+
+    // Assert
+    expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
+    expect(mockRecognitionInstance.start).toHaveBeenCalledWith(parameterTrack)
   })
 
   it('When calling stop method, it stops the recognition', () => {

--- a/src/speech.test.ts
+++ b/src/speech.test.ts
@@ -160,30 +160,30 @@ describe('speech function', () => {
   })
 
   it('When calling start method with MediaStreamTrack, it passes the track to recognition.start', () => {
-    // Arrange
+    // Arrange: 操作に必要な準備
     const recognitionObj = speech({})
     const mockAudioTrack = {
       kind: 'audio',
       readyState: 'live',
     } as MediaStreamTrack
 
-    // Act
+    // Act: 結果を得るために必要な操作
     recognitionObj.start(mockAudioTrack)
 
-    // Assert
+    // Assert: 期待される結果を確認
     expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
     expect(mockRecognitionInstance.start).toHaveBeenCalledWith(mockAudioTrack)
   })
 
   it('When calling start method with video track, it throws InvalidStateError', () => {
-    // Arrange
+    // Arrange: 操作に必要な準備
     const recognitionObj = speech({})
     const mockVideoTrack = {
       kind: 'video',
       readyState: 'live',
     } as MediaStreamTrack
 
-    // Act & Assert
+    // Act & Assert: 操作とアサーションを組み合わせる
     expect(() => recognitionObj.start(mockVideoTrack)).toThrow(DOMException)
     expect(() => recognitionObj.start(mockVideoTrack)).toThrow(
       'The provided MediaStreamTrack must be an audio track'
@@ -192,14 +192,14 @@ describe('speech function', () => {
   })
 
   it('When calling start method with ended audio track, it throws InvalidStateError', () => {
-    // Arrange
+    // Arrange: 操作に必要な準備
     const recognitionObj = speech({})
     const mockEndedTrack = {
       kind: 'audio',
       readyState: 'ended',
     } as MediaStreamTrack
 
-    // Act & Assert
+    // Act & Assert: 操作とアサーションを組み合わせる
     expect(() => recognitionObj.start(mockEndedTrack)).toThrow(DOMException)
     expect(() => recognitionObj.start(mockEndedTrack)).toThrow(
       'The provided MediaStreamTrack must be in "live" state'
@@ -208,23 +208,23 @@ describe('speech function', () => {
   })
 
   it('When audioTrack is provided in options, it uses that track on start', () => {
-    // Arrange
+    // Arrange: 操作に必要な準備
     const mockAudioTrack = {
       kind: 'audio',
       readyState: 'live',
     } as MediaStreamTrack
     const recognitionObj = speech({ audioTrack: mockAudioTrack })
 
-    // Act
+    // Act: 結果を得るために必要な操作
     recognitionObj.start()
 
-    // Assert
+    // Assert: 期待される結果を確認
     expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
     expect(mockRecognitionInstance.start).toHaveBeenCalledWith(mockAudioTrack)
   })
 
   it('When both options.audioTrack and parameter audioTrack are provided, parameter takes precedence', () => {
-    // Arrange
+    // Arrange: 操作に必要な準備
     const optionsTrack = {
       kind: 'audio',
       readyState: 'live',
@@ -235,10 +235,10 @@ describe('speech function', () => {
     } as MediaStreamTrack
     const recognitionObj = speech({ audioTrack: optionsTrack })
 
-    // Act
+    // Act: 結果を得るために必要な操作
     recognitionObj.start(parameterTrack)
 
-    // Assert
+    // Assert: 期待される結果を確認
     expect(mockRecognitionInstance.start).toHaveBeenCalledTimes(1)
     expect(mockRecognitionInstance.start).toHaveBeenCalledWith(parameterTrack)
   })

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -50,6 +50,12 @@ export interface SpeechOptions {
    * エラー時のコールバック
    */
   onError?: (error: SpeechRecognitionErrorCode) => void
+
+  /**
+   * 音声入力として使用するMediaStreamTrack
+   * 指定しない場合はデフォルトのマイクを使用
+   */
+  audioTrack?: MediaStreamTrack
 }
 
 /**
@@ -111,9 +117,29 @@ export function speech(options: SpeechOptions = {}) {
   return {
     /**
      * 音声認識を開始
+     * @param audioTrack - オプション: 使用する音声トラック
      */
-    start: () => {
-      recognition.start()
+    start: (audioTrack?: MediaStreamTrack) => {
+      const trackToUse = audioTrack || options.audioTrack
+      
+      if (trackToUse) {
+        if (trackToUse.kind !== 'audio') {
+          throw new DOMException(
+            'The provided MediaStreamTrack must be an audio track',
+            'InvalidStateError'
+          )
+        }
+        if (trackToUse.readyState !== 'live') {
+          throw new DOMException(
+            'The provided MediaStreamTrack must be in "live" state',
+            'InvalidStateError'
+          )
+        }
+        // @ts-expect-error - Web Speech API仕様の新しいメソッドシグネチャ
+        recognition.start(trackToUse)
+      } else {
+        recognition.start()
+      }
     },
 
     /**


### PR DESCRIPTION
## 概要
- 音声認識APIにMediaStreamTrackのサポートを追加
- Web Speech API仕様の`start(MediaStreamTrack audioTrack)`メソッドを実装
- 3Aパターンを使用した包括的なテストカバレッジを追加

## 変更内容
- `SpeechOptions`インターフェースに`audioTrack`オプションを追加
- `start()`メソッドで`MediaStreamTrack`パラメータをサポート
- Web Speech API仕様に従ってトラックの種類（"audio"である必要）と状態（"live"である必要）を検証
- 全シナリオをカバーする6つの新しいテストケースを追加

## テスト計画
- [x] 既存のテストがすべてパス
- [x] MediaStreamTrack機能の新しいテストがパス
- [x] Lintチェックがパス
